### PR TITLE
:books: Added new section 'Performance Evaluation'

### DIFF
--- a/MachineLearning.md
+++ b/MachineLearning.md
@@ -324,5 +324,7 @@ roughly structured into the following topics:
     Alternative decompositions of predictions are implemented in 
     `r pkg("lime")` and `r pkg("iBreakDown")`.
 
+-   *Performance Evaluation:* `r pkg(yardstick)`, `r pkg(MLmetrics)` and `r pkg(SLmetrics)` are provides a wide array of performance evaluation tools and functions. yardstick and SLmetrics follows Pythons scikit-learn module but differs in its backend - yardstick is built in with tidyverse tools and SLmetrics is built in C++. MLmetrics is built on base R.
+
 ### Links
 -   [MLOSS: Machine Learning Open Source Software](http://www.MLOSS.org/)


### PR DESCRIPTION
Hi @thothorn,

This PR is still a draft for two reasons: firstly, I do not know whether this addition falls within the scope of Task Views, secondly {SLmetrics} is still being inspected by CRAN. If this PR does not fall within the scope of the Task Views, feel free to close it.

Commit message:

* Added a brief paragraph on {SLmetrics}, {MLmetrics} and {yardstick}. The packages did not seem to fit anywhere else, and there is no clear inclusion criteria and wether these packages falls within the scope of Task View.

Best, 