### PR TITLE
Add GHA

### DIFF
--- a/.github/workflows/validate-ctv.yml
+++ b/.github/workflows/validate-ctv.yml
@@ -1,0 +1,23 @@
+on:
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - '.github/workflows/validate-ctv.yml'
+      - 'MachineLearning.md'
+  pull_request:
+    branches:
+      - main
+      - master
+    paths:
+      - '.github/workflows/validate-ctv.yml'
+      - 'MachineLearning.md'
+
+name: Validate task view
+
+jobs:
+  validate-ctv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cran-task-views/ctv/validate-ctv@main


### PR DESCRIPTION
from https://github.com/cran-task-views/ctv/tree/main/validate-ctv

via https://github.com/cran-task-views/ctv/blob/main/Maintenance.md#task-view-updates

@zeileis I ran into this when trying to open the PR directly from my IDE (Positron with the GH extension). Before I dive into details, are you generally open to changing access permissions here? 

> Although you appear to have the correct authorization credentials, the `cran-task-views` organization has enabled OAuth App access restrictions, meaning that data access to third-parties is limited. For more information on these restrictions, including how to enable this app, visit https://docs.github.com/articles/restricting-access-to-your-organization-s-data/