### PR TITLE
Added 'performance evaluation'-section

### DIFF
--- a/MachineLearning.md
+++ b/MachineLearning.md
@@ -319,5 +319,7 @@ roughly structured into the following topics:
     Alternative decompositions of predictions are implemented in
     `r pkg("lime")` and `r pkg("iBreakDown")`.
 
+-   *Performance evaluation*: `r pkg(mlr3measures)`, `r pkg(yardstick)`, `r pkg(MLmetrics)` and `r pkg(SLmetrics)` provide a wide array of classification, regression and clustering metrics for machine learning tasks. mlr3measures is a part of the mlr3verse framework, yardstick is built with tidyverse for the tidymodels framework. MLmetrics and SLmetrics are standalone packages built in base 'R' and 'C++', respectively.
+
 ### Links
 -   [MLOSS: Machine Learning Open Source Software](http://www.MLOSS.org/)


### PR DESCRIPTION
Hi @LucasKook,

I have added a new section 'Performance evaluation' for packages built specifically for evaluating ML models. Feel free to close the PR if you do not find this useful.

## Commit

* Added a new section on packages that is built for performance evaluation of machine learning tasks-
    - yardtick
    - mlr3measures
    - MLmetrics
    - SLmetrics

Best,